### PR TITLE
Send back Keycloak user ID if API key is valid and user is enabled

### DIFF
--- a/api-key-module/src/main/java/com/gwidgets/resources/ApiKeyResource.java
+++ b/api-key-module/src/main/java/com/gwidgets/resources/ApiKeyResource.java
@@ -46,7 +46,8 @@ public class ApiKeyResource {
             if (user.isEnabled()) {
                 event.event(EventType.LOGIN);
                 event.success();
-                response = Response.ok().type(MediaType.APPLICATION_JSON).build();
+                String message = "{\"userID\": \"" + user.getId() + "\"}";
+                response = Response.ok().entity(message).type(MediaType.APPLICATION_JSON).build();
             } else {
                 event.event(EventType.LOGIN_ERROR);
                 event.error("Invalid attempt for login using api-key (user corresponding to this apiKey is disabled)");


### PR DESCRIPTION
In this PR, if the API key is valid and if the user is enabled, then, send back the user ID in a JSON format to the client.

The client may want to know the userID associated to the API key (to store the in database any events related to user for example).